### PR TITLE
Fix Supabase channel ref typing

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { RealtimeChannel } from "@supabase/supabase-js";
 import {
   GameState, Player, Round, newGame, load, save, clear,
   generatePlanRows, totalsByPlayer, computePointsFromOk, SUITS, maxCardsForPlayers,
@@ -39,7 +40,7 @@ export default function Page() {
 
   // Live sync controls
   const [live, setLive] = useState(false);
-  const channelRef = useRef<ReturnType<NonNullable<ReturnType<typeof getSupabase>>>["channel"] | null>(null);
+  const channelRef = useRef<RealtimeChannel | null>(null);
   const selfUpdate = useRef(false); // prevent loops
 
   useEffect(() => { save(state); }, [state]);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
       "@/*": [
         "./*"
       ]
-    }
+    },
+    "incremental": true
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- import Supabase's RealtimeChannel type in the main page
- use the explicit channel type in the live sync ref and keep Next.js config updates from the build

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c96b0da9208321bf2d79ee1a8c4ab2